### PR TITLE
Remove Dead STUN Servers

### DIFF
--- a/src/plugins/JSTUN/JSTUN.java
+++ b/src/plugins/JSTUN/JSTUN.java
@@ -38,11 +38,7 @@ public class JSTUN implements FredPlugin, FredPluginIPDetector, FredPluginThread
 	static String[] publicSTUNServers = new String[] {
 			"stun.voipbuster.com",
 			"stun.ekiga.net",
-			"stun.ideasip.com",
-			"stun.iptel.org",
-			"stun.rixtelecom.se",
 			"stun.schlund.de",
-			"stun.softjoys.com",
 			"stun.voiparound.com",
 			"stun.voipstunt.com",
 			"stun.voxgratia.org",


### PR DESCRIPTION
Obviously, servers that don’t exist anymore are of no use, and the extraneous DNS requests for those quite specific non-existing domains might make it (slightly) easier to detect Hyphanet installations.

Maybe we should also a couple more STUN servers, and/or implement support for Google’s STUN servers (which use a different port, for which – as far as I can see – we only need to change the way to read our hard-coded list of servers because the STUN code itself can already handle servers on different ports)?