### PR TITLE
Use a Better List of Public STUN Servers

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -5,7 +5,7 @@
 	<property name="freenet-cvs-snapshot.location" location="../fred/dist/freenet.jar"/>
 	<property name="freenet-ext.location" location="../fred/lib/freenet/freenet-ext.jar"/>
 	<property name="svn.revision" value="@custom@"/>
-	<property name="source-version" value="1.5"/>
+	<property name="source-version" value="1.8"/>
 	<property name="build" location="build/"/>
 	<property name="build-test" location="build-test/"/>
 	<property name="dist" location="dist/"/>

--- a/build.xml
+++ b/build.xml
@@ -48,7 +48,7 @@
 	<!-- ================================================== -->
 
 	<target name="unit-build" depends="compile" if="junit.present" unless="skip_tests">
-		<javac srcdir="src/" destdir="${build-test}" debug="on" optimize="on" source="1.5">
+		<javac srcdir="src/" destdir="${build-test}" debug="on" optimize="on" source="${source-version}">
 			<classpath>
 				<pathelement path="${build}"/>
 				<pathelement location="${freenet-ext.location}"/>

--- a/src/plugins/JSTUN/JSTUN.java
+++ b/src/plugins/JSTUN/JSTUN.java
@@ -35,7 +35,7 @@ public class JSTUN implements FredPlugin, FredPluginIPDetector, FredPluginThread
 
 	// From http://code.google.com/p/natvpn/source/browse/trunk/stun_server_list
 	// TODO: Google STUN servers run on port 19302 instead of 3478. Is it worth supporting them?
-	static String[] publicSTUNServers = new String[] {
+	private static final String[] publicSTUNServers = new String[] {
 			"stun.voipbuster.com",
 			"stun.ekiga.net",
 			"stun.ideasip.com",
@@ -62,12 +62,12 @@ public class JSTUN implements FredPlugin, FredPluginIPDetector, FredPluginThread
 		int countLikely = 0;
 		int countUnlikely = 0;
 		for(int i=0;i<publicSTUNServers.length;i++)
-			v.add(publicSTUNServers[i]);
+			v.add(StunServer.parse(publicSTUNServers[i]));
 		while(!v.isEmpty()) {
 			if(WrapperManager.hasShutdownHookBeenTriggered()) return null;
-			String stunServer = (String) v.remove(r.nextInt(v.size()));
+			StunServer stunServer = (StunServer) v.remove(r.nextInt(v.size()));
 			try {
-				DiscoveryTest_ test = new DiscoveryTest_(iaddress, stunServer, 3478);
+				DiscoveryTest_ test = new DiscoveryTest_(iaddress, stunServer.getHostname(), stunServer.getPort());
 				// iphone-stun.freenet.de:3478
 				// larry.gloo.net:3478
 				// stun.xten.net:3478

--- a/src/plugins/JSTUN/StunServer.java
+++ b/src/plugins/JSTUN/StunServer.java
@@ -1,0 +1,90 @@
+package plugins.JSTUN;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Simple container for a STUN server’s hostname/IP address (both IPv4 and
+ * IPv6) and port number. You get an instance of this class using the
+ * {@link #parse(String)} method.
+ *
+ * <h2>Usage</h2>
+ * <pre>
+ *     StunServer stunServer = StunServer.parse("my.stun.server:12345");
+ *     System.out.println("STUN server is at " + stunServer + ".");
+ * </pre>
+ */
+public class StunServer {
+
+	/**
+	 * Parses the given string into a {@link StunServer} object. There are
+	 * six possible ways to specify a STUN server:
+	 * <p>
+	 * <ul>
+	 *     <li>A hostname.</li>
+	 *     <li>A hostname and a port number.</li>
+	 *     <li>An IPv4 address.</li>
+	 *     <li>An IPv4 address and a port number.</li>
+	 *     <li>An IPv6 address.</li>
+	 *     <li>An IPv6 address and a port number.</li>
+	 * </ul>
+	 * </p>
+	 * <p>
+	 * If no port number is specified, the default port of 3478 will be used.
+	 * </p>
+	 * <p>
+	 * An IPv6 address must be specified in square brackets, and the
+	 * {@link #getHostname() parsed hostname} will include the square
+	 * brackets.
+	 * </p>
+	 *
+	 * @param stunServerSpecification The STUN server specification (must
+	 * 		not be {@code null})
+	 * @return A parsed STUN server
+	 */
+	public static StunServer parse(String stunServerSpecification) {
+		Matcher matcher = addressParser.matcher(stunServerSpecification);
+		/* it is impossible for the regex to not match the string. */
+		matcher.matches();
+		String hostname = matcher.group(1);
+		int port = parsePortNumberFromString(matcher.group(2));
+		return new StunServer(hostname, port);
+	}
+
+	/**
+	 * Returns the hostname of the STUN server.
+	 *
+	 * @return The hostname of the STUN server
+	 */
+	public String getHostname() {
+		return hostname;
+	}
+
+	/**
+	 * Returns the port number of the STUN server.
+	 *
+	 * @return The port number of the STUN server
+	 */
+	public int getPort() {
+		return port;
+	}
+
+	@Override
+	public String toString() {
+		return hostname + ":" + port;
+	}
+
+	private StunServer(String hostname, int port) {
+		this.hostname = hostname;
+		this.port = port;
+	}
+
+	private static int parsePortNumberFromString(String portNumber) {
+		return (portNumber == null) ? 3478 : Integer.parseInt(portNumber);
+	}
+
+	private final String hostname;
+	private final int port;
+	private static final Pattern addressParser = Pattern.compile("(\\[.*]|.*?)(?::(.*))?");
+
+}

--- a/src/plugins/JSTUN/StunServer.java
+++ b/src/plugins/JSTUN/StunServer.java
@@ -1,5 +1,6 @@
 package plugins.JSTUN;
 
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -72,6 +73,20 @@ public class StunServer {
 	@Override
 	public String toString() {
 		return hostname + ":" + port;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (!(o instanceof StunServer)) {
+			return false;
+		}
+		StunServer that = (StunServer) o;
+		return port == that.port && Objects.equals(hostname, that.hostname);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(hostname, port);
 	}
 
 	private StunServer(String hostname, int port) {

--- a/src/plugins/JSTUN/StunServerList.java
+++ b/src/plugins/JSTUN/StunServerList.java
@@ -1,0 +1,56 @@
+package plugins.JSTUN;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.List;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Arrays.stream;
+import static java.util.stream.Collectors.toList;
+
+/**
+ * Loads a list of STUN servers from a given URL.
+ * <h2>Usage</h2>
+ * <pre>
+ *     List&lt;StunServer> stunServers = StunServerList.loadStunServers("https://my.stun-servers.test/stun-servers.txt");
+ *     for (StunServer stunServer : stunServers) {
+ *         doSomethingWithStunServer(stunServer);
+ *     }
+ * </pre>
+ *
+ * @see #loadStunServers(String)
+ */
+public class StunServerList {
+
+	/**
+	 * Loads a list of STUN servers from the given URL. The response is
+	 * expected to be a plain text document, comprising STUN server
+	 * specifications, one per line, separated by LF or CR/LF.
+	 *
+	 * @param stunServerListUrl The URL of the STUN server list
+	 * @return The parsed list of STUN servers
+	 * @throws IOException if an I/O error occurs
+	 */
+	public static List<StunServer> loadStunServers(String stunServerListUrl) throws IOException {
+		URLConnection httpURLConnection = new URL(stunServerListUrl).openConnection();
+		ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+		try (OutputStream outputStream = byteArrayOutputStream;
+			 InputStream inputStream = httpURLConnection.getInputStream()) {
+			byte[] buffer = new byte[1024];
+			int read;
+			while ((read = inputStream.read(buffer)) != -1) {
+				outputStream.write(buffer, 0, read);
+			}
+		}
+		String serverListString = new String(byteArrayOutputStream.toByteArray(), UTF_8);
+		return stream(serverListString.split("\r?\n"))
+				.filter(line -> !line.isEmpty())
+				.map(StunServer::parse)
+				.collect(toList());
+	}
+
+}

--- a/src/plugins/JSTUN/StunServerListTest.java
+++ b/src/plugins/JSTUN/StunServerListTest.java
@@ -1,0 +1,62 @@
+package plugins.JSTUN;
+
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+import junit.framework.TestCase;
+
+import static java.util.stream.Collectors.joining;
+
+public class StunServerListTest extends TestCase {
+
+	public void testServerListIsLoadedFromRemoteUrl() throws IOException {
+		setupServerAndVerifyReturnedList(this::getStunServerList);
+	}
+
+	public void testServerListIsAllowedToContainEmptyLines() throws IOException {
+		setupServerAndVerifyReturnedList(this::getStunServerListWithEmptyLines);
+	}
+
+	private void setupServerAndVerifyReturnedList(Supplier<String> responseSupplier) throws IOException {
+		int httpServerPort = startHttpServer(responseSupplier);
+		List<StunServer> stunServers = StunServerList.loadStunServers("http://localhost:" + httpServerPort + "/stun-servers");
+		assertEquals("number of STUN servers", 6, stunServers.size());
+		assertEquals("first STUN server", StunServer.parse("first.stun-server.test"), stunServers.get(0));
+		assertEquals("second STUN server", StunServer.parse("second.stun-server.test:1234"), stunServers.get(1));
+		assertEquals("third STUN server", StunServer.parse("127.16.17.18"), stunServers.get(2));
+		assertEquals("fourth STUN server", StunServer.parse("172.17.18.19:2021"), stunServers.get(3));
+		assertEquals("fifth STUN server", StunServer.parse("[fc00::1234]"), stunServers.get(4));
+		assertEquals("sixth STUN server", StunServer.parse("[fc00::2345]:3456"), stunServers.get(5));
+	}
+
+	private static int startHttpServer(Supplier<String> responseSupplier) throws IOException {
+		HttpServer httpServer = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+		httpServer.createContext("/stun-servers", exchange -> {
+			exchange.getResponseHeaders().set("Content-Type", "text/plain; charset=utf-8");
+			byte[] response = responseSupplier.get().getBytes(StandardCharsets.UTF_8);
+			exchange.sendResponseHeaders(200, response.length);
+			try (OutputStream body = exchange.getResponseBody()) {
+				body.write(response);
+			}
+			exchange.close();
+		});
+		httpServer.start();
+		return httpServer.getAddress().getPort();
+	}
+
+	private String getStunServerList() {
+		return Stream.of("first.stun-server.test", "second.stun-server.test:1234", "127.16.17.18", "172.17.18.19:2021", "[fc00::1234]", "[fc00::2345]:3456")
+				.collect(joining("\n"));
+	}
+
+	private String getStunServerListWithEmptyLines() {
+		return Stream.of("", "first.stun-server.test", "", "second.stun-server.test:1234", "", "", "127.16.17.18", "172.17.18.19:2021", "", "[fc00::1234]", "[fc00::2345]:3456", "", "")
+				.collect(joining("\n"));
+	}
+
+}

--- a/src/plugins/JSTUN/StunServerTest.java
+++ b/src/plugins/JSTUN/StunServerTest.java
@@ -97,4 +97,45 @@ public class StunServerTest extends TestCase {
 		assertEquals("string representation", "[fc00::4567]:45678", stunServer.toString());
 	}
 
+	public void testHashcodeIsTheSameOnStunServersWithSameHostnameAndPort() {
+		int firstHashcode = StunServer.parse("host:1234").hashCode();
+		int secondHashcode = StunServer.parse("host:1234").hashCode();
+		assertEquals("hashcodes", firstHashcode, secondHashcode);
+	}
+
+	public void testHashcodeIsDifferentOnStunServersWithDifferentHostnames() {
+		int firstHashcode = StunServer.parse("host:1234").hashCode();
+		int secondHashcode = StunServer.parse("hostname:1234").hashCode();
+		assertFalse("hashcodes should not be equal", firstHashcode == secondHashcode);
+	}
+
+	public void testHashcodeIsDifferentOnStunServersWithDifferentPorts() {
+		int firstHashcode = StunServer.parse("host:1234").hashCode();
+		int secondHashcode = StunServer.parse("host").hashCode();
+		assertFalse("hashcodes should not be equal", firstHashcode == secondHashcode);
+	}
+
+	public void testEqualsDoesNotMatchNonStunServerObjects() {
+		StunServer stunServer = StunServer.parse("host:1234");
+		assertFalse("equals must be false", stunServer.equals(new Object()));
+	}
+
+	public void testEqualsDoesNotMatchIfHostnameIsDifferent() {
+		StunServer firstStunServer = StunServer.parse("host:1234");
+		StunServer secondStunServer = StunServer.parse("hostname:1234");
+		assertFalse("equals must be false", firstStunServer.equals(secondStunServer));
+	}
+
+	public void testEqualsDoesNotMatchIfPortIsDifferent() {
+		StunServer firstStunServer = StunServer.parse("host:1234");
+		StunServer secondStunServer = StunServer.parse("host");
+		assertFalse("equals must be false", firstStunServer.equals(secondStunServer));
+	}
+
+	public void testEqualsDoesMatchIfHostnameAndPortAreIdentical() {
+		StunServer firstStunServer = StunServer.parse("host:1234");
+		StunServer secondStunServer = StunServer.parse("host:1234");
+		assertEquals("equals must be true", firstStunServer, secondStunServer);
+	}
+
 }

--- a/src/plugins/JSTUN/StunServerTest.java
+++ b/src/plugins/JSTUN/StunServerTest.java
@@ -1,0 +1,100 @@
+package plugins.JSTUN;
+
+import junit.framework.TestCase;
+
+public class StunServerTest extends TestCase {
+
+	public void testHostnameCanBeParsed() {
+		StunServer stunServer = StunServer.parse("simple.stun-server.test");
+		assertEquals("parsed server host", "simple.stun-server.test", stunServer.getHostname());
+		assertEquals("parsed server port", 3478, stunServer.getPort());
+	}
+
+	public void testHostnameWithPortNumberCanBeParsed() {
+		StunServer stunServer = StunServer.parse("with-port.stun-server.test:12345");
+		assertEquals("parsed server host", "with-port.stun-server.test", stunServer.getHostname());
+		assertEquals("parsed server port", 12345, stunServer.getPort());
+	}
+
+	public void testHostnameWithNonNumericPortNumberWillCauseException() {
+		try {
+			StunServer.parse("with-port.stun-server.test:not-a-number");
+			fail("Should have thrown an IllegalArgumentException");
+		} catch (IllegalArgumentException e) {
+			/* expected. */
+		}
+	}
+
+	public void testToStringOfHostnameContainsSensibleRepresentation() {
+		StunServer stunServer = StunServer.parse("simple.stun-server.test");
+		assertEquals("string representation", "simple.stun-server.test:3478", stunServer.toString());
+	}
+
+	public void testToStringOfHostnameWithPortContainsSensibleRepresentation() {
+		StunServer stunServer = StunServer.parse("with-port.stun-server.test:23456");
+		assertEquals("string representation", "with-port.stun-server.test:23456", stunServer.toString());
+	}
+
+	public void testIPv4AddressCanBeParsed() {
+		StunServer stunServer = StunServer.parse("172.16.17.18");
+		assertEquals("parsed server host", "172.16.17.18", stunServer.getHostname());
+		assertEquals("parsed server port", 3478, stunServer.getPort());
+	}
+
+	public void testIPv4AddressWithPortNumberCanBeParsed() {
+		StunServer stunServer = StunServer.parse("172.17.18.19:2021");
+		assertEquals("parsed server host", "172.17.18.19", stunServer.getHostname());
+		assertEquals("parsed server port", 2021, stunServer.getPort());
+	}
+
+	public void testIPv4AddressWithNonNumericPortNumberWillCauseException() {
+		try {
+			StunServer.parse("172.18.19.20:not-a-number");
+			fail("Should have thrown an IllegalArgumentException");
+		} catch (IllegalArgumentException e) {
+			/* expected. */
+		}
+	}
+
+	public void testToStringOfIPv4AddressContainsSensibleRepresentation() {
+		StunServer stunServer = StunServer.parse("172.19.20.21");
+		assertEquals("string representation", "172.19.20.21:3478", stunServer.toString());
+	}
+
+	public void testToStringOfIPv4AddressWithPortContainsSensibleRepresentation() {
+		StunServer stunServer = StunServer.parse("172.20.21.22:34567");
+		assertEquals("string representation", "172.20.21.22:34567", stunServer.toString());
+	}
+
+	public void testIPv6AddressCanBeParsed() {
+		StunServer stunServer = StunServer.parse("[fc00::1234]");
+		assertEquals("parsed server host", "[fc00::1234]", stunServer.getHostname());
+		assertEquals("parsed server port", 3478, stunServer.getPort());
+	}
+
+	public void testIPv6AddressWithPortNumberCanBeParsed() {
+		StunServer stunServer = StunServer.parse("[fc00::2345]:3456");
+		assertEquals("parsed server host", "[fc00::2345]", stunServer.getHostname());
+		assertEquals("parsed server port", 3456, stunServer.getPort());
+	}
+
+	public void testIPv6AddressWithNonNumericPortNumberWillCauseException() {
+		try {
+			StunServer.parse("[fc00::3456]:not-a-number");
+			fail("Should have thrown an IllegalArgumentException");
+		} catch (IllegalArgumentException e) {
+			/* expected. */
+		}
+	}
+
+	public void testToStringOfIPv6AddressContainsSensibleRepresentation() {
+		StunServer stunServer = StunServer.parse("[fc00::3456]");
+		assertEquals("string representation", "[fc00::3456]:3478", stunServer.toString());
+	}
+
+	public void testToStringOfIPv6AddressWithPortContainsSensibleRepresentation() {
+		StunServer stunServer = StunServer.parse("[fc00::4567]:45678");
+		assertEquals("string representation", "[fc00::4567]:45678", stunServer.toString());
+	}
+
+}


### PR DESCRIPTION
We are currently using a hard-coded and very short list of public STUN servers in the JSTUN plugin. This list of STUN servers might make a Hyphanet node stand out.

A publicly available and constantly updated list of STUN servers is available from this Github repository: https://github.com/pradt2/always-online-stun

Using this list should reduce the likelihood of detection for a Hyphanet installation from DNS and STUN requests.

(It also changes the source version in the Ant build script to 1.8, because Hyphanet has been on Java 8 for a while now, and builds the test using the same source version as the rest of the code.)